### PR TITLE
Refactor response handling and broadcaster, bump browser-controller t…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alcounit/browser-service
 go 1.25.0
 
 require (
-	github.com/alcounit/browser-controller v0.0.6
+	github.com/alcounit/browser-controller v0.0.8
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/alcounit/browser-controller v0.0.6 h1:EJ7WAgxIwrn4DTpNVET/L67+WhRQDduSuHAMxcPw4gg=
-github.com/alcounit/browser-controller v0.0.6/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
+github.com/alcounit/browser-controller v0.0.8 h1:hauzkisDiUsGoIKUoQqvBmi4/MrixzGp55PnZIUA6rY=
+github.com/alcounit/browser-controller v0.0.8/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/broadcast/broadcaster.go
+++ b/pkg/broadcast/broadcaster.go
@@ -24,13 +24,14 @@ func (s subscription[T]) matches(event T) bool {
 
 type broadcaster[T any] struct {
 	mu      sync.RWMutex
-	clients map[chan T]subscription[T]
+	subs    []subscription[T]
+	idx     map[chan T]int
 	bufSize int
 }
 
 func NewBroadcaster[T any](bufSize int) Broadcaster[T] {
 	return &broadcaster[T]{
-		clients: make(map[chan T]subscription[T]),
+		idx:     make(map[chan T]int),
 		bufSize: bufSize,
 	}
 }
@@ -44,37 +45,55 @@ func (b *broadcaster[T]) Subscribe(predicates ...func(T) bool) chan T {
 		}
 	}
 	b.mu.Lock()
-	b.clients[ch] = subscription[T]{ch: ch, predicates: active}
+	b.idx[ch] = len(b.subs)
+	b.subs = append(b.subs, subscription[T]{ch: ch, predicates: active})
 	b.mu.Unlock()
 	return ch
 }
 
+func (b *broadcaster[T]) remove(ch chan T) {
+	i, ok := b.idx[ch]
+	if !ok {
+		return
+	}
+	last := len(b.subs) - 1
+	if i != last {
+		b.subs[i] = b.subs[last]
+		b.idx[b.subs[i].ch] = i
+	}
+	b.subs[last] = subscription[T]{}
+	b.subs = b.subs[:last]
+	delete(b.idx, ch)
+	close(ch)
+}
+
 func (b *broadcaster[T]) Unsubscribe(ch chan T) {
 	b.mu.Lock()
-	_, ok := b.clients[ch]
-	if ok {
-		delete(b.clients, ch)
-		close(ch)
-	}
+	b.remove(ch)
 	b.mu.Unlock()
 }
 
 func (b *broadcaster[T]) Broadcast(event T) {
 	b.mu.RLock()
 	var slow []chan T
-	for ch, sub := range b.clients {
+	for _, sub := range b.subs {
 		if !sub.matches(event) {
 			continue
 		}
 		select {
-		case ch <- event:
+		case sub.ch <- event:
 		default:
-			slow = append(slow, ch)
+			slow = append(slow, sub.ch)
 		}
 	}
 	b.mu.RUnlock()
 
-	for _, ch := range slow {
-		b.Unsubscribe(ch)
+	if len(slow) == 0 {
+		return
 	}
+	b.mu.Lock()
+	for _, ch := range slow {
+		b.remove(ch)
+	}
+	b.mu.Unlock()
 }

--- a/pkg/broadcast/broadcaster_test.go
+++ b/pkg/broadcast/broadcaster_test.go
@@ -71,7 +71,6 @@ func TestConcurrentBroadcastUnsubscribeNoPanic(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			ch := b.Subscribe()
-			// drain so we don't become slow subscriber
 			go func() {
 				for range ch {
 				}
@@ -128,4 +127,129 @@ func TestUnsubscribeUnknownChannelNoPanic(t *testing.T) {
 	}()
 
 	ch <- 1
+}
+
+func TestUnsubscribeMiddleElementSwapsWithLast(t *testing.T) {
+	b := NewBroadcaster[int](1)
+	ch1 := b.Subscribe()
+	ch2 := b.Subscribe()
+	ch3 := b.Subscribe()
+
+	b.Unsubscribe(ch2)
+
+	b.Broadcast(99)
+
+	got1, ok1 := <-ch1
+	got3, ok3 := <-ch3
+
+	if !ok1 || got1 != 99 {
+		t.Fatalf("ch1: expected (99, true), got (%d, %v)", got1, ok1)
+	}
+	if !ok3 || got3 != 99 {
+		t.Fatalf("ch3: expected (99, true), got (%d, %v)", got3, ok3)
+	}
+
+	select {
+	case _, ok := <-ch2:
+		if ok {
+			t.Fatal("ch2 should be closed after unsubscribe")
+		}
+	default:
+		t.Fatal("ch2 should be closed (readable) after unsubscribe")
+	}
+
+	b.Unsubscribe(ch1)
+	b.Unsubscribe(ch3)
+}
+
+func TestUnsubscribeLastElement(t *testing.T) {
+	b := NewBroadcaster[int](1)
+	ch1 := b.Subscribe()
+	ch2 := b.Subscribe()
+
+	b.Unsubscribe(ch2)
+
+	b.Broadcast(7)
+
+	got, ok := <-ch1
+	if !ok || got != 7 {
+		t.Fatalf("ch1: expected (7, true), got (%d, %v)", got, ok)
+	}
+
+	b.Unsubscribe(ch1)
+}
+
+func TestUnsubscribeFirstElement(t *testing.T) {
+	b := NewBroadcaster[int](1)
+	ch1 := b.Subscribe()
+	ch2 := b.Subscribe()
+	ch3 := b.Subscribe()
+
+	b.Unsubscribe(ch1)
+
+	b.Broadcast(5)
+
+	got2, ok2 := <-ch2
+	got3, ok3 := <-ch3
+
+	if !ok2 || got2 != 5 {
+		t.Fatalf("ch2: expected (5, true), got (%d, %v)", got2, ok2)
+	}
+	if !ok3 || got3 != 5 {
+		t.Fatalf("ch3: expected (5, true), got (%d, %v)", got3, ok3)
+	}
+
+	b.Unsubscribe(ch2)
+	b.Unsubscribe(ch3)
+}
+
+func TestBroadcastMultipleSlowSubscribersRemovedInOneLock(t *testing.T) {
+	b := NewBroadcaster[int](1)
+
+	ch1 := b.Subscribe()
+	ch2 := b.Subscribe()
+	ch3 := b.Subscribe()
+
+	b.Broadcast(1)
+
+	normalCh := b.Subscribe()
+
+	b.Broadcast(2)
+
+	got, ok := <-normalCh
+	if !ok || got != 2 {
+		t.Fatalf("normal subscriber: expected (2, true), got (%d, %v)", got, ok)
+	}
+
+	for i, ch := range []chan int{ch1, ch2, ch3} {
+		for range ch {
+		}
+		if _, stillOpen := <-ch; stillOpen {
+			t.Fatalf("slow[%d] should be closed after being evicted", i)
+		}
+	}
+
+	b.Unsubscribe(normalCh)
+}
+
+func TestBroadcastNoSubscribers(t *testing.T) {
+	b := NewBroadcaster[int](1)
+	b.Broadcast(1)
+}
+
+func TestSubscribeNilPredicateIgnored(t *testing.T) {
+	b := NewBroadcaster[int](2)
+	ch := b.Subscribe(nil, func(v int) bool { return v > 0 }, nil)
+
+	b.Broadcast(-1)
+	b.Broadcast(1)
+	b.Unsubscribe(ch)
+
+	var got []int
+	for v := range ch {
+		got = append(got, v)
+	}
+	if len(got) != 1 || got[0] != 1 {
+		t.Fatalf("expected [1], got %v", got)
+	}
 }

--- a/service/browser/browser.go
+++ b/service/browser/browser.go
@@ -1,9 +1,10 @@
 package browser
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"strconv"
 
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,11 @@ import (
 	"github.com/alcounit/browser-service/pkg/broadcast"
 	"github.com/alcounit/browser-service/pkg/event"
 	"github.com/go-chi/chi/v5"
+)
+
+var (
+	sseDataPrefix = []byte("data: ")
+	sseDataSuffix = []byte("\n\n")
 )
 
 type Service struct {
@@ -38,41 +44,39 @@ func (s *Service) Create(rw http.ResponseWriter, req *http.Request) {
 	namespace := chi.URLParam(req, "namespace")
 	if namespace == "" {
 		log.Error().Msg("missing required url param: namespace")
-		writeErrorResponse(rw, http.StatusBadRequest, "namespace must be provided", nil)
+		writeJSONError(rw, http.StatusBadRequest, "namespace must be provided", nil)
 		return
 	}
 
 	log = log.With().Str("namespace", namespace).Logger()
 	if req.Body == nil {
 		log.Error().Msg("empty request body")
-		writeErrorResponse(rw, http.StatusBadRequest, "request body must not be empty", nil)
+		writeJSONError(rw, http.StatusBadRequest, "request body must not be empty", nil)
 		return
 	}
 
 	var browser browserv1.Browser
 	if err := json.NewDecoder(req.Body).Decode(&browser); err != nil {
 		log.Err(err).Msg("failed to decode request body")
-		writeErrorResponse(rw, http.StatusBadRequest, "invalid request body", err)
+		writeJSONError(rw, http.StatusBadRequest, "invalid request body", err)
 		return
 	}
 
 	if browser.Spec.BrowserName == "" || browser.Spec.BrowserVersion == "" {
 		log.Error().Msg("failed to create browser")
-		writeErrorResponse(rw, http.StatusBadRequest, "required field is empty", nil)
+		writeJSONError(rw, http.StatusBadRequest, "required field is empty", nil)
 		return
 	}
 
 	result, err := s.client.BrowserV1().Browsers(namespace).Create(req.Context(), &browser, metav1.CreateOptions{})
 	if err != nil {
 		log.Err(err).Msg("failed to create browser")
-		writeErrorResponse(rw, http.StatusInternalServerError, "failed to create browser", err)
+		writeJSONError(rw, http.StatusInternalServerError, "failed to create browser", err)
 		return
 	}
 
 	log.Info().Str("browserName", result.Name).Msg("browser created successfully")
-
-	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(result)
+	writeJSON(rw, result)
 }
 
 func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
@@ -81,7 +85,7 @@ func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
 	namespace, name := chi.URLParam(req, "namespace"), chi.URLParam(req, "name")
 	if namespace == "" || name == "" {
 		log.Error().Msg("missing required url params: namespace or name")
-		writeErrorResponse(rw, http.StatusBadRequest, "namespace and name must be provided", nil)
+		writeJSONError(rw, http.StatusBadRequest, "namespace and name must be provided", nil)
 		return
 	}
 
@@ -95,14 +99,12 @@ func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		log.Err(err).Msg("failed to get browser")
-		writeErrorResponse(rw, http.StatusInternalServerError, "failed to retrieve browser", err)
+		writeJSONError(rw, http.StatusInternalServerError, "failed to retrieve browser", err)
 		return
 	}
 
 	log.Info().Str("phase", string(result.Status.Phase)).Msg("browser retrieved successfully")
-
-	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(result)
+	writeJSON(rw, result)
 }
 
 func (s *Service) Delete(rw http.ResponseWriter, req *http.Request) {
@@ -111,7 +113,7 @@ func (s *Service) Delete(rw http.ResponseWriter, req *http.Request) {
 	namespace, name := chi.URLParam(req, "namespace"), chi.URLParam(req, "name")
 	if namespace == "" || name == "" {
 		log.Error().Msg("missing required url params: namespace or name")
-		writeErrorResponse(rw, http.StatusBadRequest, "namespace and name must be provided", nil)
+		writeJSONError(rw, http.StatusBadRequest, "namespace and name must be provided", nil)
 		return
 	}
 
@@ -125,7 +127,7 @@ func (s *Service) Delete(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		log.Err(err).Msg("failed to delete browser")
-		writeErrorResponse(rw, http.StatusInternalServerError, "failed to delete browser", err)
+		writeJSONError(rw, http.StatusInternalServerError, "failed to delete browser", err)
 		return
 	}
 
@@ -139,7 +141,7 @@ func (s *Service) List(rw http.ResponseWriter, req *http.Request) {
 	namespace := chi.URLParam(req, "namespace")
 	if namespace == "" {
 		log.Error().Msg("missing required url param: namespace")
-		writeErrorResponse(rw, http.StatusBadRequest, "namespace must be provided", nil)
+		writeJSONError(rw, http.StatusBadRequest, "namespace must be provided", nil)
 		return
 	}
 
@@ -148,13 +150,12 @@ func (s *Service) List(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		if apierr.IsNotFound(err) {
 			log.Warn().Msg("no browsers found in namespace")
-			rw.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(rw).Encode([]*browserv1.Browser{})
+			writeJSON(rw, []*browserv1.Browser{})
 			return
 		}
 
 		log.Err(err).Msg("failed to list browsers")
-		writeErrorResponse(rw, http.StatusInternalServerError, "failed to list browsers", err)
+		writeJSONError(rw, http.StatusInternalServerError, "failed to list browsers", err)
 		return
 	}
 
@@ -163,9 +164,7 @@ func (s *Service) List(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	log.Info().Int("count", len(browsers)).Msg("browsers listed successfully")
-
-	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(browsers)
+	writeJSON(rw, browsers)
 }
 
 func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
@@ -174,7 +173,7 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 	namespace := chi.URLParam(req, "namespace")
 	if namespace == "" {
 		log.Error().Msg("missing required url param: namespace")
-		writeErrorResponse(rw, http.StatusBadRequest, "namespace must be provided", nil)
+		writeJSONError(rw, http.StatusBadRequest, "namespace must be provided", nil)
 		return
 	}
 
@@ -188,7 +187,7 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 	flusher, ok := rw.(http.Flusher)
 	if !ok {
 		log.Error().Msg("response writer does not support http.Flusher")
-		writeErrorResponse(rw, http.StatusInternalServerError, "streaming not supported", nil)
+		writeJSONError(rw, http.StatusInternalServerError, "streaming not supported", nil)
 		return
 	}
 
@@ -229,23 +228,45 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 				log.Err(err).Msg("failed to encode browser event")
 				return
 			}
-			fmt.Fprintf(rw, "data: %s\n\n", data)
+			rw.Write(sseDataPrefix)
+			rw.Write(data)
+			rw.Write(sseDataSuffix)
 			flusher.Flush()
 		}
 	}
 }
 
-func writeErrorResponse(rw http.ResponseWriter, status int, msg string, err error) {
+type errorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+	Details string `json:"details"`
+}
+
+func writeJSON(rw http.ResponseWriter, v any) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(v); err != nil {
+		writeJSONError(rw, http.StatusInternalServerError, "failed to encode response", err)
+		return err
+	}
 	rw.Header().Set("Content-Type", "application/json")
-	rw.WriteHeader(status)
-	json.NewEncoder(rw).Encode(map[string]string{
-		"error":   http.StatusText(status),
-		"message": msg,
-		"details": func() string {
-			if err != nil {
-				return err.Error()
-			}
-			return ""
-		}(),
+	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	buf.WriteTo(rw)
+	return nil
+}
+
+func writeJSONError(rw http.ResponseWriter, status int, msg string, err error) {
+	details := ""
+	if err != nil {
+		details = err.Error()
+	}
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(errorResponse{
+		Error:   http.StatusText(status),
+		Message: msg,
+		Details: details,
 	})
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	rw.WriteHeader(status)
+	buf.WriteTo(rw)
 }

--- a/service/browser/browser_test.go
+++ b/service/browser/browser_test.go
@@ -436,9 +436,44 @@ func TestEventsChannelClosed(t *testing.T) {
 	}
 }
 
+func TestEventsNilBrowserSkipped(t *testing.T) {
+	b := broadcast.NewBroadcaster[event.BrowserEvent](2)
+	svc := NewService(nil, nil, b)
+
+	req := newRequestWithParams(http.MethodGet, "/", nil, map[string]string{"namespace": "default"})
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	rw := &recordingRW{header: make(http.Header)}
+	done := make(chan struct{})
+
+	go func() {
+		svc.Events(rw, req)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	b.Broadcast(event.BrowserEvent{EventType: event.EventTypeAdded, Browser: nil})
+
+	if waitFor(func() bool { return rw.Len() > 0 }, 150*time.Millisecond) {
+		cancel()
+		t.Fatal("expected nil browser event to be skipped")
+	}
+
+	b.Broadcast(event.BrowserEvent{EventType: event.EventTypeAdded, Browser: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}}})
+
+	if !waitFor(func() bool { return rw.Len() > 0 }, 2*time.Second) {
+		cancel()
+		t.Fatal("timed out waiting for valid event")
+	}
+
+	cancel()
+	<-done
+}
+
 func TestWriteErrorResponse(t *testing.T) {
 	rw := httptest.NewRecorder()
-	writeErrorResponse(rw, http.StatusBadRequest, "bad", errors.New("details"))
+	writeJSONError(rw, http.StatusBadRequest, "bad", errors.New("details"))
 
 	if rw.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rw.Code)

--- a/service/browserconfig/browserconfig.go
+++ b/service/browserconfig/browserconfig.go
@@ -1,9 +1,10 @@
 package browserconfig
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"strconv"
 
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,11 @@ import (
 	"github.com/alcounit/browser-service/pkg/broadcast"
 	"github.com/alcounit/browser-service/pkg/event"
 	"github.com/go-chi/chi/v5"
+)
+
+var (
+	sseDataPrefix = []byte("data: ")
+	sseDataSuffix = []byte("\n\n")
 )
 
 type Service struct {
@@ -71,9 +77,7 @@ func (s *Service) Create(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	log.Info().Str("browserConfigName", result.Name).Msg("browser config created successfully")
-
-	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(result)
+	writeJSON(rw, result)
 }
 
 func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
@@ -102,9 +106,7 @@ func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	log.Info().Msg("browser config retrieved successfully")
-
-	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(result)
+	writeJSON(rw, result)
 }
 
 func (s *Service) Delete(rw http.ResponseWriter, req *http.Request) {
@@ -151,8 +153,7 @@ func (s *Service) List(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		if apierr.IsNotFound(err) {
 			log.Warn().Msg("no browser configs found in namespace")
-			rw.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(rw).Encode([]*browserconfigv1.BrowserConfig{})
+			writeJSON(rw, []*browserconfigv1.BrowserConfig{})
 			return
 		}
 
@@ -166,9 +167,7 @@ func (s *Service) List(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	log.Info().Int("count", len(configs)).Msg("browser configs listed successfully")
-
-	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(configs)
+	writeJSON(rw, configs)
 }
 
 func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
@@ -232,23 +231,45 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 				log.Err(err).Msg("failed to encode browser config event")
 				return
 			}
-			fmt.Fprintf(rw, "data: %s\n\n", data)
+			rw.Write(sseDataPrefix)
+			rw.Write(data)
+			rw.Write(sseDataSuffix)
 			flusher.Flush()
 		}
 	}
 }
 
-func writeErrorResponse(rw http.ResponseWriter, status int, msg string, err error) {
+type errorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+	Details string `json:"details"`
+}
+
+func writeJSON(rw http.ResponseWriter, v any) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(v); err != nil {
+		writeErrorResponse(rw, http.StatusInternalServerError, "failed to encode response", err)
+		return err
+	}
 	rw.Header().Set("Content-Type", "application/json")
-	rw.WriteHeader(status)
-	json.NewEncoder(rw).Encode(map[string]string{
-		"error":   http.StatusText(status),
-		"message": msg,
-		"details": func() string {
-			if err != nil {
-				return err.Error()
-			}
-			return ""
-		}(),
+	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	buf.WriteTo(rw)
+	return nil
+}
+
+func writeErrorResponse(rw http.ResponseWriter, status int, msg string, err error) {
+	details := ""
+	if err != nil {
+		details = err.Error()
+	}
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(errorResponse{
+		Error:   http.StatusText(status),
+		Message: msg,
+		Details: details,
 	})
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	rw.WriteHeader(status)
+	buf.WriteTo(rw)
 }

--- a/service/browserconfig/browserconfig_test.go
+++ b/service/browserconfig/browserconfig_test.go
@@ -388,6 +388,147 @@ func TestEventsChannelClosed(t *testing.T) {
 	}
 }
 
+func TestEventsNameFilter(t *testing.T) {
+	b := broadcast.NewBroadcaster[event.BrowserConfigEvent](2)
+	svc := NewService(nil, nil, b)
+
+	req := newRequestWithParams(http.MethodGet, "/?name=target", nil, map[string]string{"namespace": "default"})
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	rw := &recordingRW{header: make(http.Header)}
+	done := make(chan struct{})
+
+	go func() {
+		svc.Events(rw, req)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	b.Broadcast(event.BrowserConfigEvent{EventType: event.EventTypeAdded, BrowserConfig: &browserconfigv1.BrowserConfig{ObjectMeta: metav1.ObjectMeta{Name: "other"}}})
+
+	if waitFor(func() bool { return rw.Len() > 0 }, 150*time.Millisecond) {
+		cancel()
+		t.Fatal("unexpected event write for non-matching name")
+	}
+
+	b.Broadcast(event.BrowserConfigEvent{EventType: event.EventTypeAdded, BrowserConfig: &browserconfigv1.BrowserConfig{ObjectMeta: metav1.ObjectMeta{Name: "target"}}})
+
+	if !waitFor(func() bool { return rw.Len() > 0 }, 2*time.Second) {
+		cancel()
+		t.Fatal("timed out waiting for matching event")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for handler to exit")
+	}
+}
+
+func TestWriteErrorResponse(t *testing.T) {
+	rw := httptest.NewRecorder()
+	writeErrorResponse(rw, http.StatusBadRequest, "bad request", errors.New("detail"))
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rw.Code)
+	}
+	if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+	if cl := rw.Header().Get("Content-Length"); cl == "" {
+		t.Fatal("expected Content-Length to be set")
+	}
+
+	var got map[string]string
+	if err := json.NewDecoder(rw.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if got["message"] != "bad request" {
+		t.Fatalf("unexpected message: %q", got["message"])
+	}
+	if got["details"] != "detail" {
+		t.Fatalf("unexpected details: %q", got["details"])
+	}
+}
+
+func TestWriteErrorResponseNoError(t *testing.T) {
+	rw := httptest.NewRecorder()
+	writeErrorResponse(rw, http.StatusInternalServerError, "internal", nil)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+
+	var got map[string]string
+	if err := json.NewDecoder(rw.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if got["details"] != "" {
+		t.Fatalf("expected empty details, got %q", got["details"])
+	}
+}
+
+func TestWriteJSONSetsContentLength(t *testing.T) {
+	cfg := &browserconfigv1.BrowserConfig{ObjectMeta: metav1.ObjectMeta{Name: "cfg"}}
+	rw := httptest.NewRecorder()
+
+	if err := writeJSON(rw, cfg); err != nil {
+		t.Fatalf("writeJSON returned error: %v", err)
+	}
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+	if cl := rw.Header().Get("Content-Length"); cl == "" {
+		t.Fatal("expected Content-Length to be set")
+	}
+
+	var got browserconfigv1.BrowserConfig
+	if err := json.NewDecoder(rw.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if got.Name != "cfg" {
+		t.Fatalf("unexpected name: %q", got.Name)
+	}
+}
+
+func TestEventsNilBrowserConfigSkipped(t *testing.T) {
+	b := broadcast.NewBroadcaster[event.BrowserConfigEvent](2)
+	svc := NewService(nil, nil, b)
+
+	req := newRequestWithParams(http.MethodGet, "/", nil, map[string]string{"namespace": "default"})
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	rw := &recordingRW{header: make(http.Header)}
+	done := make(chan struct{})
+
+	go func() {
+		svc.Events(rw, req)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	b.Broadcast(event.BrowserConfigEvent{EventType: event.EventTypeAdded, BrowserConfig: nil})
+
+	if waitFor(func() bool { return rw.Len() > 0 }, 150*time.Millisecond) {
+		cancel()
+		t.Fatal("expected nil browserconfig event to be skipped")
+	}
+
+	b.Broadcast(event.BrowserConfigEvent{EventType: event.EventTypeAdded, BrowserConfig: &browserconfigv1.BrowserConfig{ObjectMeta: metav1.ObjectMeta{Name: "cfg"}}})
+
+	if !waitFor(func() bool { return rw.Len() > 0 }, 2*time.Second) {
+		cancel()
+		t.Fatal("timed out waiting for valid event")
+	}
+
+	cancel()
+	<-done
+}
+
 // fakes
 
 type fakeLister struct {

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-http://localhost:8080}"
-NAMESPACE="${NAMESPACE:-default}"
+NAMESPACE="${NAMESPACE:-e2e-$(date +%s)}"
+NAMESPACE_CREATED=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES_DIR="${SCRIPT_DIR}/fixtures"
 
@@ -13,6 +14,23 @@ NC='\033[0m'
 
 PASS=0
 FAIL=0
+
+cleanup() {
+  if [ -n "$NAMESPACE_CREATED" ]; then
+    echo -e "\n${YELLOW}▶ Cleanup${NC}"
+    kubectl delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+    echo "  namespace ${NAMESPACE} scheduled for deletion"
+  fi
+}
+trap cleanup EXIT
+
+if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+  kubectl create namespace "$NAMESPACE"
+  NAMESPACE_CREATED="true"
+  echo "namespace ${NAMESPACE} created"
+else
+  echo "namespace ${NAMESPACE} already exists"
+fi
 
 pass() { echo -e "  ${GREEN}PASS${NC}  $1"; PASS=$((PASS + 1)); }
 fail() { echo -e "  ${RED}FAIL${NC}  $1"; FAIL=$((FAIL + 1)); }


### PR DESCRIPTION
## Changes

  **Dependency**
  - Bump `github.com/alcounit/browser-controller` v0.0.6 → v0.0.8.

  **broadcast (`pkg/broadcast`)**
  - Replace the `map[chan T]subscription[T]` registry with a slice + index map,
    enabling O(1) swap-with-last removal (`remove(ch)`).
  - Batch slow-consumer cleanup under a single lock (early return when none are
    slow) instead of per-channel `Unsubscribe` re-locking.

  **HTTP responses (`service/browser`, `service/browserconfig`)**
  - Add shared `writeJSON` / `writeJSONError` helpers with a typed
    `errorResponse`, replacing `writeErrorResponse` and the repeated
    `Header().Set(...) + json.NewEncoder(rw).Encode(...)` pattern.
  - Buffer responses and set `Content-Length`; handle JSON encode errors.
  - Write SSE events using precomputed `[]byte` chunks (`data: ` / `\n\n`)
    instead of `fmt.Fprintf`.