### PR TITLE
Structured request-scoped logging + service.hostname provenance label

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -88,22 +88,14 @@ func main() {
 	brwSvc := browsersvc.NewService(cs, browserLister, browserBroadcaster)
 	cfgSvc := browserconfigsvc.NewService(cs, configLister, configBroadcaster)
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to resolve hostname, using fallback")
+		hostname = "unknown"
+	}
+
 	router := chi.NewRouter()
-	router.Use(func(next http.Handler) http.Handler {
-		fn := func(rw http.ResponseWriter, req *http.Request) {
-			logger := log.With().
-				Str("method", req.Method).
-				Str("path", req.URL.Path).
-				Str("reqID", uuid.NewString()).
-				Logger()
-
-			ctx := req.Context()
-			ctx = logctx.IntoContext(ctx, logger)
-
-			next.ServeHTTP(rw, req.WithContext(ctx))
-		}
-		return http.HandlerFunc(fn)
-	})
+	router.Use(requestContextMiddleware(log, hostname))
 
 	router.Route("/api/v1/namespaces/{namespace}", func(r chi.Router) {
 		r.Route("/browsers", func(r chi.Router) {
@@ -306,5 +298,27 @@ func browserConfigEventHandler(queue chan<- event.BrowserConfigEvent) cache.Reso
 				BrowserConfig: cfg.DeepCopy(),
 			})
 		},
+	}
+}
+
+func requestContextMiddleware(logger zerolog.Logger, hostname string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(rw http.ResponseWriter, req *http.Request) {
+
+			l := logger.With().
+				Str("method", req.Method).
+				Str("path", req.URL.Path).
+				Str("reqId", uuid.NewString()).
+				Str("hostname", hostname).
+				Logger()
+
+			req.Header.Set("X-Browser-Service-Hostname", hostname)
+
+			ctx := req.Context()
+			ctx = logctx.IntoContext(ctx, l)
+
+			next.ServeHTTP(rw, req.WithContext(ctx))
+		}
+		return http.HandlerFunc(fn)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alcounit/browser-service
 go 1.25.0
 
 require (
-	github.com/alcounit/browser-controller v0.0.8
+	github.com/alcounit/browser-controller v0.0.9
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/alcounit/browser-controller v0.0.8 h1:hauzkisDiUsGoIKUoQqvBmi4/MrixzGp55PnZIUA6rY=
-github.com/alcounit/browser-controller v0.0.8/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
+github.com/alcounit/browser-controller v0.0.9 h1:Z10ryX+/QrgV+kB/Y+WT0WIsigcB2cPS9RVv7V/auSg=
+github.com/alcounit/browser-controller v0.0.9/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/service/browser/browser.go
+++ b/service/browser/browser.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcounit/browser-service/pkg/broadcast"
 	"github.com/alcounit/browser-service/pkg/event"
 	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
 )
 
 var (
@@ -62,11 +63,19 @@ func (s *Service) Create(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	log = log.With().Dict("Browser", zerolog.Dict().
+		Str("hostname", browser.Name).
+		Str("type", browser.Spec.BrowserName).
+		Str("version", browser.Spec.BrowserVersion)).
+		Logger()
+
 	if browser.Spec.BrowserName == "" || browser.Spec.BrowserVersion == "" {
 		log.Error().Msg("failed to create browser")
 		writeJSONError(rw, http.StatusBadRequest, "required field is empty", nil)
 		return
 	}
+
+	setServiceLabel(req, &browser)
 
 	result, err := s.client.BrowserV1().Browsers(namespace).Create(req.Context(), &browser, metav1.CreateOptions{})
 	if err != nil {
@@ -75,7 +84,7 @@ func (s *Service) Create(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.Info().Str("browserName", result.Name).Msg("browser created successfully")
+	log.Info().Msg("browser created successfully")
 	writeJSON(rw, result)
 }
 
@@ -89,7 +98,12 @@ func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log = log.With().Str("namespace", namespace).Str("browserName", name).Logger()
+	log = log.With().
+		Str("namespace", namespace).
+		Dict("Browser", zerolog.Dict().
+			Str("hostname", name)).
+		Logger()
+
 	result, err := s.lister.Browsers(namespace).Get(name)
 	if err != nil {
 		if apierr.IsNotFound(err) {
@@ -103,7 +117,7 @@ func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.Info().Str("phase", string(result.Status.Phase)).Msg("browser retrieved successfully")
+	log.Info().Msg("browser retrieved successfully")
 	writeJSON(rw, result)
 }
 
@@ -117,7 +131,11 @@ func (s *Service) Delete(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log = log.With().Str("namespace", namespace).Str("name", name).Logger()
+	log = log.With().
+		Str("namespace", namespace).
+		Dict("Browser", zerolog.Dict().
+			Str("hostname", name)).
+		Logger()
 
 	if err := s.client.BrowserV1().Browsers(namespace).Delete(req.Context(), name, metav1.DeleteOptions{}); err != nil {
 		if apierr.IsNotFound(err) {
@@ -181,7 +199,7 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 
 	nameFilter := req.URL.Query().Get("name")
 	if nameFilter != "" {
-		log = log.With().Str("name", nameFilter).Logger()
+		log = log.With().Str("nameFilter", nameFilter).Logger()
 	}
 
 	flusher, ok := rw.(http.Flusher)
@@ -222,6 +240,12 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 			if evt.Browser == nil {
 				continue
 			}
+
+			log.Info().
+				Dict("Browser", zerolog.Dict().
+					Str("name", evt.Browser.GetName())).
+				Str("eventType", string(evt.EventType)).
+				Msg("Browser event occurred")
 
 			data, err := json.Marshal(evt)
 			if err != nil {
@@ -269,4 +293,17 @@ func writeJSONError(rw http.ResponseWriter, status int, msg string, err error) {
 	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
 	rw.WriteHeader(status)
 	buf.WriteTo(rw)
+}
+
+func setServiceLabel(req *http.Request, template *browserv1.Browser) {
+	hostname := req.Header.Get("X-Browser-Service-Hostname")
+	if hostname == "" {
+		return
+	}
+
+	if template.ObjectMeta.Labels == nil {
+		template.ObjectMeta.Labels = map[string]string{}
+	}
+
+	template.ObjectMeta.Labels[browserv1.SelenosisServiceLabelKey] = hostname
 }

--- a/service/browserconfig/browserconfig.go
+++ b/service/browserconfig/browserconfig.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcounit/browser-service/pkg/broadcast"
 	"github.com/alcounit/browser-service/pkg/event"
 	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
 )
 
 var (
@@ -63,6 +64,10 @@ func (s *Service) Create(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	log = log.With().Dict("BrowserConfig", zerolog.Dict().
+		Str("name", cfg.Name)).
+		Logger()
+
 	if len(cfg.Spec.Browsers) == 0 {
 		log.Error().Msg("failed to create browser config")
 		writeErrorResponse(rw, http.StatusBadRequest, "required field is empty", nil)
@@ -76,7 +81,7 @@ func (s *Service) Create(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.Info().Str("browserConfigName", result.Name).Msg("browser config created successfully")
+	log.Info().Msg("browser config created successfully")
 	writeJSON(rw, result)
 }
 
@@ -90,7 +95,11 @@ func (s *Service) Get(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log = log.With().Str("namespace", namespace).Str("browserConfigName", name).Logger()
+	log = log.With().
+		Str("namespace", namespace).
+		Dict("BrowserConfig", zerolog.Dict().
+			Str("name", name)).
+		Logger()
 
 	result, err := s.lister.BrowserConfigs(namespace).Get(name)
 	if err != nil {
@@ -119,7 +128,11 @@ func (s *Service) Delete(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log = log.With().Str("namespace", namespace).Str("name", name).Logger()
+	log = log.With().
+		Str("namespace", namespace).
+		Dict("BrowserConfig", zerolog.Dict().
+			Str("name", name)).
+		Logger()
 
 	if err := s.client.BrowserconfigV1().BrowserConfigs(namespace).Delete(req.Context(), name, metav1.DeleteOptions{}); err != nil {
 		if apierr.IsNotFound(err) {
@@ -184,7 +197,7 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 
 	nameFilter := req.URL.Query().Get("name")
 	if nameFilter != "" {
-		log = log.With().Str("name", nameFilter).Logger()
+		log = log.With().Str("nameFilter", nameFilter).Logger()
 	}
 
 	flusher, ok := rw.(http.Flusher)
@@ -225,6 +238,12 @@ func (s *Service) Events(rw http.ResponseWriter, req *http.Request) {
 			if evt.BrowserConfig == nil {
 				continue
 			}
+
+			log.Info().
+				Dict("BrowserConfig", zerolog.Dict().
+					Str("name", evt.BrowserConfig.GetName())).
+				Str("eventType", string(evt.EventType)).
+				Msg("BrowserConfig event occurred")
 
 			data, err := json.Marshal(evt)
 			if err != nil {


### PR DESCRIPTION
Adds request-scoped structured logging and records which browser-service instance handled a create, mirroring the hostname/label provenance approach used in selenosis

https://github.com/alcounit/selenosis/issues/75