### PR TITLE
feat: Build multi-arch (linux/amd64 + linux/arm64) container images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           VERSION: ${{ steps.meta.outputs.version }}
-          PLATFORM: linux/amd64
+          PLATFORM: linux/amd64,linux/arm64
           EXTRA_TAGS: -t ${{ secrets.REGISTRY }}/browser-service:latest
         run: |
           make deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.25.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-RUN go build -trimpath -ldflags="-s -w" -o /out/service ./cmd/service
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/service ./cmd/service
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /


### PR DESCRIPTION
Cross-compile the Go binary via BuildKit: pin the builder stage to $BUILDPLATFORM and pass the auto-provided TARGETOS/TARGETARCH to `go build` (GOOS/GOARCH), dropping the hardcoded GOARCH=amd64.

CI now builds linux/amd64,linux/arm64.

Related to https://github.com/alcounit/selenosis/issues/77